### PR TITLE
dgbsupport link update

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Stigting</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Ondersteuning</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Ondersteuning</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontak</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Skenk</a></li>  
             </ul>

--- a/ar/index.html
+++ b/ar/index.html
@@ -203,7 +203,7 @@
                 <li><a class="rtl" href="https://digibytefoundation.io" target="_blank">مؤسسة</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a class="rtl" href="https://www.dgbwiki.com" target="_blank">ويكي</a></li>
-                <li><a class="rtl" href="https://dgbsupport.digiassetx.com" target="_blank">الدعم</a></li>
+                <li><a class="rtl" href="https://dgbsupport.digiassetx.com" data-lity>الدعم</a></li>
 		    	<li><a class="rtl" href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">اتصل</a></li>
                 <li><a class="rtl" href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">تبرع</a></li>  
             </ul>

--- a/bg/index.html
+++ b/bg/index.html
@@ -204,7 +204,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Подкрепи</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Подкрепи</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Контакт</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Дарения</a></li>  
             </ul>

--- a/cs/index.html
+++ b/cs/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Nadace</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Podpora</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Podpora</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/da/index.html
+++ b/da/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundament</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Hjælp</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Hjælp</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/de/index.html
+++ b/de/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Stiftung</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Spenden</a></li>  
             </ul>

--- a/el/index.html
+++ b/el/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Ίδρυμα</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Υποστήριξη</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Υποστήριξη</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Επικοινωνία</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Δωρεές</a></li>  
             </ul>

--- a/en-au/index.html
+++ b/en-au/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/en-ca/index.html
+++ b/en-ca/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/en-gb/index.html
+++ b/en-gb/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/en-in/index.html
+++ b/en-in/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/en-ng/index.html
+++ b/en-ng/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/en-nz/index.html
+++ b/en-nz/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/es/index.html
+++ b/es/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundación</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Apoyo</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Apoyo</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contacto</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donar</a></li>  
             </ul>

--- a/fa/index.html
+++ b/fa/index.html
@@ -203,7 +203,7 @@
                 <li><a class="rtl" href="https://digibytefoundation.io" target="_blank">بنیاد</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a class="rtl" href="https://www.dgbwiki.com" target="_blank">ویکی</a></li>
-                <li><a class="rtl" href="https://dgbsupport.digiassetx.com" target="_blank">پشتیبانی</a></li>
+                <li><a class="rtl" href="https://dgbsupport.digiassetx.com" data-lity>پشتیبانی</a></li>
 		    	<li><a class="rtl" href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">تماس با ما</a></li>
                 <li><a class="rtl" href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">حمایت از ما</a></li>  
             </ul>

--- a/fi/index.html
+++ b/fi/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Tuki</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Tuki</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Ota yhteyttä</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Lahjoita</a></li>  
             </ul>

--- a/fil/index.html
+++ b/fil/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/fr/index.html
+++ b/fr/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fondation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Soutien</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Soutien</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Faire un don</a></li>  
             </ul>

--- a/hi/index.html
+++ b/hi/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">विकी</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">सहयोग</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>सहयोग</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">संपर्क करें</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">दान करें</a></li>  
             </ul>

--- a/hr/index.html
+++ b/hr/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fondacija</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Podrška</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Podrška</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donacije</a></li>  
             </ul>

--- a/hu/index.html
+++ b/hu/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Alapítvány</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Támogatás</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Támogatás</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kapcsolat</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Adományozz</a></li>  
             </ul>

--- a/id/index.html
+++ b/id/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Yayasan</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Dukungan</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Dukungan</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontak</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donasi</a></li>  
             </ul>

--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donate</a></li>  
             </ul>

--- a/it/index.html
+++ b/it/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fondazione</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Supporto</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Supporto</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contatta</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Dona</a></li>  
             </ul>

--- a/ja/index.html
+++ b/ja/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">財団</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">ウィキ</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">サポート</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>サポート</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">コンタクト</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">寄付</a></li>  
             </ul>

--- a/ko/index.html
+++ b/ko/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">DigiByte 재단</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">도움말</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>도움말</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">문의하기</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">기부하기</a></li>
             </ul>

--- a/ms/index.html
+++ b/ms/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Yayasan</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Bantuan</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Bantuan</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Hubungi</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Sumbangan</a></li>
             </ul>

--- a/nb/index.html
+++ b/nb/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Hjelp</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Hjelp</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donèr</a></li>  
             </ul>

--- a/nl/index.html
+++ b/nl/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Stichting</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Ondersteuning</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Ondersteuning</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Doneer</a></li>  
             </ul>

--- a/pl/index.html
+++ b/pl/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundacja</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Pomoc</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Pomoc</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Wspomóż</a></li>  
             </ul>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundação</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Suporte</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Suporte</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contato</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Doação</a></li>  
             </ul>

--- a/pt/index.html
+++ b/pt/index.html
@@ -229,7 +229,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundação</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Suporte</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Suporte</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contato</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Doação</a></li>  
             </ul>

--- a/ro/index.html
+++ b/ro/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundație</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Ajutor</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Ajutor</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Contact</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donează</a></li>  
             </ul>

--- a/ru/index.html
+++ b/ru/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Фонд</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Служба поддержки</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Служба поддержки</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Контакты</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Пожертвовать</a></li>  
             </ul>

--- a/sl/index.html
+++ b/sl/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Fundacija</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Podpora</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Podpora</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Doniraj</a></li>  
             </ul>

--- a/sq/index.html
+++ b/sq/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Mbështetje</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Mbështetje</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Dhuroj</a></li>  
             </ul>

--- a/sv/index.html
+++ b/sv/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Foundation</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Support</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Support</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Kontakt</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Donera</a></li>  
             </ul>

--- a/sw/index.html
+++ b/sw/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Msingi</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Msaada</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Msaada</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Wasiliana</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Changia</a></li>  
             </ul>

--- a/th/index.html
+++ b/th/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">ผู้ก่อตั้ง</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">สนับสนุน</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>สนับสนุน</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">ติดต่อ</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">บริจาค</a></li>  
             </ul>

--- a/tr/index.html
+++ b/tr/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Vakıf</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wıkı</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Destek</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Destek</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">İletişim</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Bağış</a></li>  
             </ul>

--- a/vi/index.html
+++ b/vi/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">Nền tảng</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">Ủng hộ</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>Ủng hộ</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">Liên hệ</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">Quyên góp</a></li>  
             </ul>

--- a/zh/index.html
+++ b/zh/index.html
@@ -203,7 +203,7 @@
                 <li><a href="https://digibytefoundation.io" target="_blank">基金会</a></li>
 				<li><a href="https://dgbat.org" target="_blank">DGBAT</a></li>
 				<li><a href="https://www.dgbwiki.com" target="_blank">Wiki</a></li>
-                <li><a href="https://dgbsupport.digiassetx.com" target="_blank">支持</a></li>
+                <li><a href="https://dgbsupport.digiassetx.com" data-lity>支持</a></li>
 		    	<li><a href="https://www.dgbwiki.com/index.php?title=Contact" target="_blank">联络</a></li>
                 <li><a href="https://www.dgbwiki.com/index.php?title=Donate" target="_blank">捐款</a></li>  
             </ul>


### PR DESCRIPTION
This PR makes the dgbsupport link in the top right panel (ul class "home-content__social") open as lity lightbox instead of new tab.