### PR TITLE
Re-added CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.digibyte.org


### PR DESCRIPTION
Re-added CNAME record file for www.digibyte.org, this was removed with latest merge which broke the site.
That was my mistake, I thought it was no longer needed.