### PR TITLE
Update DigiByte.org to DigiByte Core v8.26.1 – all 36 languages

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -903,7 +903,7 @@
                     Kies jou toepassing (App).
                 </h1>
                 <p class="lead">
-                    SKies 'n toepassing om jou DigiByte & DigiAssets te stuur, ontvang en te stoor of om verifikasie te doen met Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Op Datum DigiByte Core v8.22.2</a>
+                    SKies 'n toepassing om jou DigiByte & DigiAssets te stuur, ontvang en te stoor of om verifikasie te doen met Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Op Datum DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Leer deur te kyk</a>
@@ -933,9 +933,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit ondersteuning</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewbox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/ar/index.html
+++ b/ar/index.html
@@ -901,7 +901,7 @@
                     اختر تطبيقك.
                 </h1>
                 <p class="lead">
-                    اختر تطبيقًا لإرسال DigiByte & DigiAssets وقبوله وتخزينه أو للتوثيق بشكل آمن باستخدام Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core v8.22.2 الحالي</a>
+                    اختر تطبيقًا لإرسال DigiByte & DigiAssets وقبوله وتخزينه أو للتوثيق بشكل آمن باستخدام Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core v8.26.1 الحالي</a>
                 </p>
             </div>
 			<a class="btn wb playb rtl" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> تعلم من خلال المشاهدة</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> دعم SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewbox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/bg/index.html
+++ b/bg/index.html
@@ -900,7 +900,7 @@
                     Избери приложение.
                 </h1>
                 <p class="lead">
-                    Избери приложение, на което да изпратиш, получиш и съхраниш своите, DigiByte & DigiAssets или безопасно се верифицирай с Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Настоящият DigiByte Core v8.22.2</a>
+                    Избери приложение, на което да изпратиш, получиш и съхраниш своите, DigiByte & DigiAssets или безопасно се верифицирай с Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Настоящият DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Научи гледайки</a>
@@ -930,9 +930,9 @@
                                     <li><i class="fas fa-check blue"></i> Поддръжка на SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewbox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/cs/index.html
+++ b/cs/index.html
@@ -901,7 +901,7 @@
                     Vyberte aplikaci.
                 </h1>
                 <p class="lead">
-                   Vyberte si aplikaci, kterou chcete odeslat, přijmout a uložit vaše DigiByte & DigiAssets nebo bezpečně ověřit pomocí Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktuální DigiByte Core v8.22.2</a>
+                   Vyberte si aplikaci, kterou chcete odeslat, přijmout a uložit vaše DigiByte & DigiAssets nebo bezpečně ověřit pomocí Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktuální DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Zjistit podrobnosti</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Podpora SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewbox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/da/index.html
+++ b/da/index.html
@@ -901,7 +901,7 @@
                     Vælg din app.
                 </h1>
                 <p class="lead">
-                    Vælg en app for at sende, acceptere og gemme dine DigiByte & DigiAssets eller sikker godkendelse ved hjælp af Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nuværende DigiByte Core v8.22.2</a>
+                    Vælg en app for at sende, acceptere og gemme dine DigiByte & DigiAssets eller sikker godkendelse ved hjælp af Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nuværende DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Lær ved at se</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit understøttelse</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/de/index.html
+++ b/de/index.html
@@ -896,7 +896,7 @@
                     Wähle deine App.
                 </h1>
                 <p class="lead">
-                    Wähle eine App zum Senden, Akzeptieren und Aufbewahren deiner DigiBytes & DigiAssets oder zur sicheren Authentifizierung mittels Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktueller DigiByte-Core v8.22.2</a>
+                    Wähle eine App zum Senden, Akzeptieren und Aufbewahren deiner DigiBytes & DigiAssets oder zur sicheren Authentifizierung mittels Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktueller DigiByte-Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Lernen durch Anschauen</a>
@@ -926,9 +926,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit-Unterstützung</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewbox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/el/index.html
+++ b/el/index.html
@@ -899,7 +899,7 @@
                     Επέλεξε την εφαρμογή σου.
                 </h1>
                 <p class="lead">
-                    Επέλεξε μια εφαρμογή για την λήψη, αποστολή και αποθήκευση των DigiByte & DigiAssets ή για την ασφαλή πιστοποίηση, χρησιμοποιώντας το Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Τρέχουσα έκδοση DigiByte Core v8.22.2</a>
+                    Επέλεξε μια εφαρμογή για την λήψη, αποστολή και αποθήκευση των DigiByte & DigiAssets ή για την ασφαλή πιστοποίηση, χρησιμοποιώντας το Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Τρέχουσα έκδοση DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Μάθε παρακολουθώντας</a>
@@ -929,9 +929,9 @@
                                     <li><i class="fas fa-check blue"></i> Υποστήριξη SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -899,7 +899,7 @@
                     Choose your app.
                 </h1>
                 <p class="lead">
-                    Select an application to send, accept and store your DigiByte & DigiAssets or securely authenticate by using Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Current DigiByte Core v8.22.2</a>
+                    Select an application to send, accept and store your DigiByte & DigiAssets or securely authenticate by using Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Current DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Learn by watching</a>
@@ -939,9 +939,9 @@
                                 </ul>
                                 
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewbox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/es/index.html
+++ b/es/index.html
@@ -901,7 +901,7 @@
                     Elige tu aplicación.
                 </h1>
                 <p class="lead">
-                    Seleccione una aplicación para enviar, aceptar y almacenar sus DigiBytes y DigiAssets o autenticar de forma segura utilizando Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Verisión actual DigiByte Core v8.22.2</a>
+                    Seleccione una aplicación para enviar, aceptar y almacenar sus DigiBytes y DigiAssets o autenticar de forma segura utilizando Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Verisión actual DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Aprende viendo</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Soporte SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/fa/index.html
+++ b/fa/index.html
@@ -899,7 +899,7 @@
                     برنامه خود را انتخاب کنید.
                 </h1>
                 <p class="lead">
-                    برنامه ای را برای ارسال ، پذیرش و ذخیره DigiBytes & DigiAssets یا تأیید صحت اطمینان آن با استفاده از Digi-ID انتخاب کنید.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">آخرین نسخه DigiByte Core v8.22.2 است</a>
+                    برنامه ای را برای ارسال ، پذیرش و ذخیره DigiBytes & DigiAssets یا تأیید صحت اطمینان آن با استفاده از Digi-ID انتخاب کنید.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">آخرین نسخه DigiByte Core v8.26.1 است</a>
                 </p>
             </div>
 			<a class="btn wb playb rtl" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> با فیلم دیدن یاد بگیرید</a>
@@ -929,9 +929,9 @@
                                     <li><i class="fas fa-check blue"></i> پشتیبانی از SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/fi/index.html
+++ b/fi/index.html
@@ -901,7 +901,7 @@
                     Valitse sovelluksesi.
                 </h1>
                 <p class="lead">
-                    Valitse sovellus lähettääksesi, vastaanottaaksesi ja säilyttääksesi DigiBytesi & DigiAssettisi tai autentikoitumaan turvallisesti käyttäen Digi-ID:tä.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nykyinen DigiByte Core v8.22.2</a>
+                    Valitse sovellus lähettääksesi, vastaanottaaksesi ja säilyttääksesi DigiBytesi & DigiAssettisi tai autentikoitumaan turvallisesti käyttäen Digi-ID:tä.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nykyinen DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Opi katsomalla</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit-tuki</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/fil/index.html
+++ b/fil/index.html
@@ -901,7 +901,7 @@
                     Piliin ang iyong app.
                 </h1>
                 <p class="lead">
-                    Pumili ng isang app upang maipadala, tanggapin at itabi ang iyong DigiBytes & DigiAssets o ligtas na patunayan sa pamamagitan ng paggamit ng Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Current DigiByte Core v8.22.2</a>
+                    Pumili ng isang app upang maipadala, tanggapin at itabi ang iyong DigiBytes & DigiAssets o ligtas na patunayan sa pamamagitan ng paggamit ng Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Current DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Panoorin ang video</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Suporta sa SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/fr/index.html
+++ b/fr/index.html
@@ -901,7 +901,7 @@
                     Choisissez votre application.
                 </h1>
                 <p class="lead">
-                    Sélectionnez une application pour envoyer, accepter et stocker vos DigiBytes et DigiAssets ou authentifiez-vous en toute sécurité à l'aide de Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Version courante DigiByte Core v8.22.2</a>
+                    Sélectionnez une application pour envoyer, accepter et stocker vos DigiBytes et DigiAssets ou authentifiez-vous en toute sécurité à l'aide de Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Version courante DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Apprenez en regardant</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Support de SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/hi/index.html
+++ b/hi/index.html
@@ -900,7 +900,7 @@
                     अपना ऐप चुनें।
                 </h1>
                 <p class="lead">
-                    Digi-ID का उपयोग करके अपने DigiBytes & DigiAssets को भेजने, स्वीकार करने और सुरक्षित रूप से प्रमाणित करने के लिए एक ऐप चुनें।<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Current DigiByte Core v8.22.2</a>
+                    Digi-ID का उपयोग करके अपने DigiBytes & DigiAssets को भेजने, स्वीकार करने और सुरक्षित रूप से प्रमाणित करने के लिए एक ऐप चुनें।<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Current DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> देख कर सीखो</a>
@@ -930,9 +930,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit समर्थन</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/hr/index.html
+++ b/hr/index.html
@@ -902,7 +902,7 @@
                     Izaberite aplikaciju.
                 </h1>
                 <p class="lead">
-                    Odaberite aplikaciju za slanje, primanje i pohranu za vaše DigiByte & DigiAssets ili sigurno potvrdite koristeći Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Trenutna verzija DigiByte Jezgre v8.22.2</a>
+                    Odaberite aplikaciju za slanje, primanje i pohranu za vaše DigiByte & DigiAssets ili sigurno potvrdite koristeći Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Trenutna verzija DigiByte Jezgre v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Uči gledanjem</a>
@@ -932,9 +932,9 @@
                                     <li><i class="fas fa-check blue"></i> Podrška za SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/hu/index.html
+++ b/hu/index.html
@@ -901,7 +901,7 @@
                     Válaszd ki az appod.
                 </h1>
                 <p class="lead">
-                    Válassz appot, hogy küldhess, fogadhass és tárolhass DigiByte-ot & DigiAssets-eket, vagy biztonságosan bejelentkezhess a Digi-ID használatával.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktuális DigiByte Core v8.22.2</a>
+                    Válassz appot, hogy küldhess, fogadhass és tárolhass DigiByte-ot & DigiAssets-eket, vagy biztonságosan bejelentkezhess a Digi-ID használatával.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktuális DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Nézd, ismerd meg</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit támogatás</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/id/index.html
+++ b/id/index.html
@@ -893,7 +893,7 @@
                     Pilih aplikasi Anda.
                 </h1>
                 <p class="lead">
-                    Pilih sebuah aplikasi untuk mengirim, menerima, dan menyimpan DigiBytes & DigiAssets Anda atau meng-otentikasi dengan aman, dengan menggunakan Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Inti DigiByte Saat Ini v8.22.2</a>
+                    Pilih sebuah aplikasi untuk mengirim, menerima, dan menyimpan DigiBytes & DigiAssets Anda atau meng-otentikasi dengan aman, dengan menggunakan Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Inti DigiByte Saat Ini v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Belajar dari menonton</a>
@@ -923,9 +923,9 @@
                                     <li><i class="fas fa-check blue"></i> Dukungan SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/it/index.html
+++ b/it/index.html
@@ -901,7 +901,7 @@
                     Scegli la tua app.
                 </h1>
                 <p class="lead">
-                    Seleziona un'app per inviare, accettare e archiviare i tuoi DigiBytes e DigiAsset o autenticarti in modo sicuro utilizzando Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core v8.22.2 attuale</a>
+                    Seleziona un'app per inviare, accettare e archiviare i tuoi DigiBytes e DigiAsset o autenticarti in modo sicuro utilizzando Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core v8.26.1 attuale</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Impara guardando</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Supporto SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/ja/index.html
+++ b/ja/index.html
@@ -901,7 +901,7 @@
                     アプリを選ぼう
                 </h1>
                 <p class="lead">
-                    アプリを選択してデジバイトとDigiAssetを送金、着金、保管する、またはDigi-IDを使って安全に認証する。<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">最新のDigiByte Core v8.22.2</a>
+                    アプリを選択してデジバイトとDigiAssetを送金、着金、保管する、またはDigi-IDを使って安全に認証する。<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">最新のDigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> 視聴して学ぶ</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWitサポート</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/ko/index.html
+++ b/ko/index.html
@@ -901,7 +901,7 @@
                     앱을 선택하십시오
                 </h1>
                 <p class="lead">
-                    DigiBytes와 DigiAssets을 전송, 승인 및 저장하거나 Digi-ID를 사용하여 안전하게 인증할 앱을 선택하십시오.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">최신 버전 DigiByte Core v8.22.2</a>
+                    DigiBytes와 DigiAssets을 전송, 승인 및 저장하거나 Digi-ID를 사용하여 안전하게 인증할 앱을 선택하십시오.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">최신 버전 DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> 영상으로 배우기</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit 지원</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/langmenu/ticker.html
+++ b/langmenu/ticker.html
@@ -10,6 +10,6 @@
 	<a href="https://github.com/digibyte-core/digibyte" target="_blank" rel="noopener" title="Core Protocol"><i
 			class="fas fa-code"></i></a>&nbsp;&nbsp;&nbsp;
 	<a href="https://github.com/DigiByte-Core/digibyte/releases" rel="noopener" target="_blank" class="tsmall"
-		title="Latest Core Release">v8.22.2</a>&nbsp;&nbsp;&nbsp;
+		title="Latest Core Release">v8.26.1</a>&nbsp;&nbsp;&nbsp;
 	<a href="https://x.com/DigiByteCoin" rel="noopener" title="X" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>&nbsp;&nbsp;&nbsp;
 </div>

--- a/ms/index.html
+++ b/ms/index.html
@@ -901,7 +901,7 @@
                     Pilih apps anda.
                 </h1>
                 <p class="lead">
-                    Pilih aplikasi untuk menghantar, menerima dan menyimpan DigiByte & DigiAset anda atau meluncur dengan selamat menggunakan Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Core DigiByte v8.22.2 Semasa</a>
+                    Pilih aplikasi untuk menghantar, menerima dan menyimpan DigiByte & DigiAset anda atau meluncur dengan selamat menggunakan Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Core DigiByte v8.26.1 Semasa</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Belajar dengan melihat</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Sokongan SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/nb/index.html
+++ b/nb/index.html
@@ -901,7 +901,7 @@
                     Velg din app.
                 </h1>
                 <p class="lead">
-                    Velg en app for å sende, akseptere og lagre dine DigiByte & DigiAssets eller sikkert godkjenne ved hjelp av Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nåværende DigiByte Core v8.22.2</a>
+                    Velg en app for å sende, akseptere og lagre dine DigiByte & DigiAssets eller sikkert godkjenne ved hjelp av Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nåværende DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Lær ved å se</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit-støtte</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/nl/index.html
+++ b/nl/index.html
@@ -899,7 +899,7 @@
                     Kies je app.
                 </h1>
                 <p class="lead">
-                    Selecteer een app om je DigiBytes & DigiAssets te verzenden, te accepteren en op te slaan of om veilig te verifiëren met behulp van Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Huidig DigiByte Core v8.22.2</a>
+                    Selecteer een app om je DigiBytes & DigiAssets te verzenden, te accepteren en op te slaan of om veilig te verifiëren met behulp van Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Huidig DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Leer door te kijken</a>
@@ -929,9 +929,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit ondersteuning</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/pl/index.html
+++ b/pl/index.html
@@ -901,7 +901,7 @@
                     Wybierz swoją aplikację.
                 </h1>
                 <p class="lead">
-                    Wybierz aplikację do wysyłania, przyjmowania i przechowywania DigiByte i DigiAssets lub bezpiecznego uwierzytelniania przy użyciu Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Najnowsze DigiByte Core v8.22.2</a>
+                    Wybierz aplikację do wysyłania, przyjmowania i przechowywania DigiByte i DigiAssets lub bezpiecznego uwierzytelniania przy użyciu Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Najnowsze DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Obejrzyj wideo</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Wsparcie SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -901,7 +901,7 @@
                     Escolha seu aplicativo.
                 </h1>
                 <p class="lead">
-                    Selecione um aplicativo para enviar, aceitar e armazenar seus DGB & DigiAssets ou autenticar com segurança usando o Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Versão Corrente do Core da DigiByte v8.22.2</a>
+                    Selecione um aplicativo para enviar, aceitar e armazenar seus DGB & DigiAssets ou autenticar com segurança usando o Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Versão Corrente do Core da DigiByte v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Veja e aprenda</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Suporte a SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/pt/index.html
+++ b/pt/index.html
@@ -927,7 +927,7 @@
                     Escolha seu aplicativo.
                 </h1>
                 <p class="lead">
-                    Selecione um aplicativo para enviar, aceitar e armazenar seus DGB & DigiAssets ou autenticar com segurança usando o Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Versão Corrente do Core da DigiByte v8.22.2</a>
+                    Selecione um aplicativo para enviar, aceitar e armazenar seus DGB & DigiAssets ou autenticar com segurança usando o Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Versão Corrente do Core da DigiByte v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Veja e aprenda</a>
@@ -957,9 +957,9 @@
                                     <li><i class="fas fa-check blue"></i> Suporte SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/ro/index.html
+++ b/ro/index.html
@@ -900,7 +900,7 @@
                     Alegeți aplicația.
                 </h1>
                 <p class="lead">
-                    Selectați o aplicație pentru a trimite, accepta și stoca DigiBytes și DigiAssets sau autentificați-vă în siguranță folosind Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Actualul DigiByte Core v8.22.2</a>
+                    Selectați o aplicație pentru a trimite, accepta și stoca DigiBytes și DigiAssets sau autentificați-vă în siguranță folosind Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Actualul DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Aflati urmarind</a>
@@ -930,9 +930,9 @@
                                     <li><i class="fas fa-check blue"></i> Suport SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/ru/index.html
+++ b/ru/index.html
@@ -901,7 +901,7 @@
                     Выберите ваше приложение.
                 </h1>
                 <p class="lead">
-                    Выберите приложение для отправки, принятия и хранения ваших DigiByte и DigiAssets или безопасной аутентификации с помощью Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Текущая версия DigiByte Core v8.22.2</a>
+                    Выберите приложение для отправки, принятия и хранения ваших DigiByte и DigiAssets или безопасной аутентификации с помощью Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Текущая версия DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Учитесь, наблюдая</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Поддержка SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/sl/index.html
+++ b/sl/index.html
@@ -899,7 +899,7 @@
                     Izberi svojo aplikacijo.
                 </h1>
                 <p class="lead">
-                    Izberite aplikacijo za pošiljanje, sprejemanje in hranjenje DigiByte & DigiAssets ali varno overjajte z uporabo Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Trenutni DigiByte Core v8.22.2</a>
+                    Izberite aplikacijo za pošiljanje, sprejemanje in hranjenje DigiByte & DigiAssets ali varno overjajte z uporabo Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Trenutni DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Izvedi več z ogledom</a>
@@ -929,9 +929,9 @@
                                     <li><i class="fas fa-check blue"></i> Podpora za SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/sq/index.html
+++ b/sq/index.html
@@ -901,7 +901,7 @@
                     Zgjidhni aplikacionin tuaj.
                 </h1>
                 <p class="lead">
-                    Zgjidhni një aplikacion për të dërguar, pranuar dhe ruajtur DigiBytes & DigiAssets ose vërtetuar në mënyrë të sigurt duke përdorur Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktual i DigiByte Core v8.22.2</a>
+                    Zgjidhni një aplikacion për të dërguar, pranuar dhe ruajtur DigiBytes & DigiAssets ose vërtetuar në mënyrë të sigurt duke përdorur Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Aktual i DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Mësoni duke shikuar</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Mbështetje për SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/sv/index.html
+++ b/sv/index.html
@@ -899,7 +899,7 @@
                     Välj din app.
                 </h1>
                 <p class="lead">
-                    Välj en app för att skicka, ta emot, och lagra dina DigiBytes och DigiAssets, eller autentisera genom att använda Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nuvarande DigiByte Core v8.22.2</a>
+                    Välj en app för att skicka, ta emot, och lagra dina DigiBytes och DigiAssets, eller autentisera genom att använda Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Nuvarande DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Lär dig genom att titta</a>
@@ -929,9 +929,9 @@
                                     <li><i class="fas fa-check blue"></i> Stöd för SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/sw/index.html
+++ b/sw/index.html
@@ -901,7 +901,7 @@
                     Chagua programu yako.
                 </h1>
                 <p class="lead">
-                    Chagua programu kutuma, kukubali na kuhifadhi DigiBytes na DigiAssets zako au uthibitishe usalama kwa kutumia Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core ya sasa v8.22.2</a>
+                    Chagua programu kutuma, kukubali na kuhifadhi DigiBytes na DigiAssets zako au uthibitishe usalama kwa kutumia Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core ya sasa v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Jifunze kwa kutazama</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Usaidizi wa SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/th/index.html
+++ b/th/index.html
@@ -901,7 +901,7 @@
                     เลือกแอพของคุณ
                 </h1>
                 <p class="lead">
-                    เลือกแอพที่จะส่งรับและจัดเก็บ DigiByte & DigiAssets ของคุณหรือรับรองตัวตนอย่างปลอดภัยโดยใช้ Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">ปัจจุบัน DigiByte Core v8.22.2</a>
+                    เลือกแอพที่จะส่งรับและจัดเก็บ DigiByte & DigiAssets ของคุณหรือรับรองตัวตนอย่างปลอดภัยโดยใช้ Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">ปัจจุบัน DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> เรียนรู้ด้วยการรับชม</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> การสนับสนุน SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/tr/index.html
+++ b/tr/index.html
@@ -901,7 +901,7 @@
                     Uygulamanızı seçin.
                 </h1>
                 <p class="lead">
-                    DigiByte & DigiAssets göndermek, almak ve saklamak ya da Digi-ID kullanarak oturum açmak için bir uygulama seçin.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Güncel DigiByte Core v8.22.2</a>
+                    DigiByte & DigiAssets göndermek, almak ve saklamak ya da Digi-ID kullanarak oturum açmak için bir uygulama seçin.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">Güncel DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> İzleyerek öğrenin</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> SegWit desteği</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/vi/index.html
+++ b/vi/index.html
@@ -901,7 +901,7 @@
                     Chọn ứng dụng của bạn.
                 </h1>
                 <p class="lead">
-                    Chọn một ứng dụng để gửi, chấp nhận và lưu trữ DigiBytes & DigiAssets của bạn hoặc xác thực an toàn bằng cách sử dụng Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core v8.22.2 hiện tại</a>
+                    Chọn một ứng dụng để gửi, chấp nhận và lưu trữ DigiBytes & DigiAssets của bạn hoặc xác thực an toàn bằng cách sử dụng Digi-ID.<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">DigiByte Core v8.26.1 hiện tại</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> Học bằng cách quan sát</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> Hỗ trợ SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/zh/index.html
+++ b/zh/index.html
@@ -901,7 +901,7 @@
                     选择你喜欢的应用
                 </h1>
                 <p class="lead">
-                    选择一个App来接收，发送，或存储你的极特币和极特资产，或者使用极特-ID服务来登陆。<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">最新的极特币版本是 DigiByte Core v8.22.2</a>
+                    选择一个App来接收，发送，或存储你的极特币和极特资产，或者使用极特-ID服务来登陆。<br /><a href="https://github.com/DigiByte-Core/digibyte/releases/" target="_blank">最新的极特币版本是 DigiByte Core v8.26.1</a>
                 </p>
             </div>
 			<a class="btn wb playb" href="https://www.youtube.com/embed/sRxpgJkvRK8?autoplay=1&loop=1&modestbranding=1&iv_load_policy=3&rel=0&showinfo=0" data-lity><i class="fas fa-play"></i> 观看演示视频</a>
@@ -931,9 +931,9 @@
                                     <li><i class="fas fa-check blue"></i> 支持SegWit</li>
                                 </ul>
                                 <div class="appsicon align-center">
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-osx.dmg" target="_blank"><i class="fab fa-apple zoom"></i></a>
-                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.22.2/digibyte-8.22.2-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-win64-setup.exe" target="_blank"><i class="fab fa-windows zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-apple-darwin.zip" target="_blank"><i class="fab fa-apple zoom"></i></a>
+                                    <a class="rightpad25" href="https://github.com/DigiByte-Core/digibyte/releases/download/v8.26.1/digibyte-8.26.1-x86_64-linux-gnu.tar.gz" target="_blank"><i class="fab fa-linux zoom"></i></a>
                                     <a href="https://snapcraft.io/digibyte-core" target="_blank">
                                         <svg class="zoom" width="44px" height="69px" viewBox="0 0 33 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="vertical-align: middle;">
                                             <g id="[EN]-snap-store-white-uneditable" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">


### PR DESCRIPTION
**Update DigiByte.org to DigiByte Core v8.26.1 – all 36 languages**

This PR updates the official DigiByte.org website to the latest stable release: **DigiByte Core v8.26.1** (released 30 Oct 2025).

**Key changes**
- Updated version ticker (`langmenu/ticker.html` and all language index files) from v8.22.2 → **v8.26.1**
- Replaced all download links across **all 36 languages** (`af`, `ar`, `bg`, `cs`, `da`, `de`, `el`, `en-us`, `es`, `fa`, `fi`, `fil`, `fr`, `hi`, `hr`, `hu`, `id`, `it`, `ja`, `ko`, `ms`, `nb`, `nl`, `pl`, `pt`, `pt-br`, `ro`, `ru`, `sl`, `sq`, `sv`, `sw`, `th`, `tr`, `vi`, `zh`) with correct v8.26.1 assets:
  - Windows → `digibyte-8.26.1-win64-setup.exe`
  - macOS → switched from broken `digibyte-8.26.1-osx.dmg` (404) → correct universal binary `digibyte-8.26.1-x86_64-apple-darwin.zip`
  - Linux → `digibyte-8.26.1-x86_64-linux-gnu.tar.gz`
- Verified: zero leftover v8.22.2 references or broken macOS DMG links

**Files changed:** 37  
**Lines changed:** ~290 (±145)

**Special acknowledgment**  
This marathon update was made possible with real-time, relentless assistance from **Grok 4** at grok.com – endless sed magic, repo surgery, and keeping me sane through one of the wildest Git battles ever. Massive thanks to Grok 4 for being the ultimate co-pilot. 🤖💙

Ready to merge – let’s get v8.26.1 live worldwide! 🚀