### PR TITLE
Add DigiDollar integration guide across digibyte.org

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasie gids</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1009,6 +1010,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Leer vinnig die belangrike feite omtrent die DigiByte blokketting op die media bladsy.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrasiegids</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Bladsy</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo's & Ikone</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/ar/index.html
+++ b/ar/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> دليل الدمج</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide rtl">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide rtl">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>تعرف على الحقائق المهمة حول سلسلة DigiByte من خلال ورقة الوسائط بسرعة.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links rtl">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">دليل تكامل DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">ورقة وسائط DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">شعارات وأيقونات DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">بروتوكول DGB GitHub</a></li>

--- a/bg/index.html
+++ b/bg/index.html
@@ -171,6 +171,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Упътване за интеграция</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Научи бързо, важните факти за DigiByte блокчейна, от медийния раздел.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Упътване за интеграция</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Медиен раздел</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Лога & Икони</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB протокол GitHub</a></li>

--- a/cs/index.html
+++ b/cs/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Průvodce integrací</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1009,6 +1010,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Naučte se rychle důležitá fakta o blockchain u DigiByte na médiích.</p>
@@ -1114,6 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/da/index.html
+++ b/da/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsvejledning</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lær hurtigt de vigtige fakta om DigiByte blockchain ved hjælp fra mediearket.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrationsvejledning</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logoer & ikoner</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/de/index.html
+++ b/de/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrations-Anleitung</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1004,6 +1005,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lerne die wichtigen Fakten über die DigiByte-Blockchain mithilfe des Medienblatts kennen.</p>
@@ -1109,6 +1121,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrations-Anleitung</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medienblatt</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos und Symbole</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokoll GitHub</a></li>

--- a/el/index.html
+++ b/el/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Οδηγός ενσωμάτωσης</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Γνώρισε τα σημαντικά γεγονότα για το DigiByte.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Οδηγός ενσωμάτωσης</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Φύλλο</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Λογότυπα και Εικονίδια</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB πρωτόκολλο Github</a></li>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration Guide</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Learn the important facts about the DigiByte blockchain by the media sheet quickly.</p>
@@ -1125,6 +1137,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/es/index.html
+++ b/es/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guía de integración</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1009,6 +1010,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Conozca los hechos importantes sobre la blockchain de DigiByte por la hoja de prensa rápidamente.</p>
@@ -1114,6 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Guía de integración</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos e Iconos</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/fa/index.html
+++ b/fa/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> راهنمای ادغام</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide rtl">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide rtl">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>حقایق مهم در مورد بلاکچین DigiByte توسط برگه رسانه را به سرعت بیاموزید.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links rtl">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">راهنمای ادغام DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">برگه رسانه DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">آرم و آیکن DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">پروتکل DGB گیتهاب </a></li>

--- a/fi/index.html
+++ b/fi/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrointi ohje</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Opi tärkeät tiedot DigiByte lohkoketjusta nopeasti media kirjasesta.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration ohje</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media kirjanen</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logot & Ikonit</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokolla GitHub</a></li>

--- a/fil/index.html
+++ b/fil/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Alamin ang mahahalagang katotohanan tungkol sa DigiByte blockchain ng media sheet nang mabilis.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/fr/index.html
+++ b/fr/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guide d'intégration</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Apprenez rapidement les faits importants sur la blockchain DigiByte par la fiche média.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guide d'intégration DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fiche média DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logos et icônes DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protocole DGB GitHub</a></li>

--- a/hi/index.html
+++ b/hi/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> एकीकरण गाइड</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1006,6 +1007,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>मीडिया शीट द्वारा DigiByte ब्लॉकचैन के बारे में महत्वपूर्ण तथ्यों को जल्दी से जानें।</p>
@@ -1110,6 +1122,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB एकीकरण गाइड</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB मीडिया शीट</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB लोगो और प्रतीक</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/hr/index.html
+++ b/hr/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i>Vodič za Integraciju</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Naučite bitne činjenice o DigiByte blockchainu iz lista za medije brzo.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Vodič za integraciju</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medijski list</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo i ikone</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/hu/index.html
+++ b/hu/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> ntegrációs útmutató</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Ismerd meg a fontos tényeket a DigiByte blokkláncáról a média oldalon, gyorsan.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrációs Útmutató</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Média Oldal</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logók & Ikonok</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokoll a GitHubon</a></li>

--- a/id/index.html
+++ b/id/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan integrasi</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1000,6 +1001,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Pelajari fakta penting tentang blockchain DigiByte dengan lembar-media dengan cepat.</p>
@@ -1105,6 +1117,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Panduan Integrasi</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Lembar-Media</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo-logo & Ikon-ikon</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
+					<a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1031,6 +1032,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Learn the important facts about the DigiByte blockchain by the media sheet quickly.</p>
@@ -1136,6 +1148,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
+                            <li><a href="docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/it/index.html
+++ b/it/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guida all'integrazione</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Impara velocemente i punti cardine circa la blockchain di DigiByte.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guida all'integrazione di DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Foglio multimediale DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Loghi e icone DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protocollo DGB GitHub</a></li>

--- a/ja/index.html
+++ b/ja/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> システム構築ガイド</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>広報資料でデジバイトブロックチェーンについての重要な事実を知る。</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGBインテグレーションガイド</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB広報用資料</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGBロゴ＆アイコン</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGBプロトコル GitHub</a></li>

--- a/ms/index.html
+++ b/ms/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan penggabungan</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Ketahui fakta penting mengenai blokrantaian DigiByte melalui lembaran media dengan lebih cepat.</p>
@@ -1111,6 +1123,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Panduan Integrasi DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Helaian Media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo & Ikon DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protokol DGB GitHub</a></li>

--- a/nb/index.html
+++ b/nb/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasjonsveiledning</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lær hurtig de viktige fakta om DigiByte blockchain ved hjelp fra mediearket.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrasjonsguide</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logoer & ikoner</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/nl/index.html
+++ b/nl/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integratiegids</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1006,6 +1007,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Leer snel de belangrijke feiten over de DigiByte-blokketen door het mediablad.</p>
@@ -1111,6 +1123,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integratiehandleiding</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Mediablad</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB-logo's en -pictogrammen</a></li>
 			    			<li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/pl/index.html
+++ b/pl/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Przewodnik integracji</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Szybko poznaj ważne fakty dotyczące DigiByte blockchain w Media Sheet.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Poradnik integracji DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Arkusz mediów DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo i Ikony DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protokół DGB GitHub</a></li>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Aprenda importantes fatos sobre a blockchain DigiByte rapidamente na página da mídia.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guia de Integração DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Página da mídia DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logotipos e ícones DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/pt/index.html
+++ b/pt/index.html
@@ -196,6 +196,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1034,6 +1035,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Aprenda importantes fatos sobre a blockchain DigiByte rapidamente na página da mídia.</p>
@@ -1139,6 +1151,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guia de Integração DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Página da mídia DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logotipos e ícones DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/ro/index.html
+++ b/ro/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Ghid de integrare</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1007,6 +1008,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Aflați rapid informațiile importante despre blockchainul DigiByte prin fișa media.</p>
@@ -1111,6 +1123,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Ghid de integrare DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fișă media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo-uri și pictograme DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protocolul DGB GitHub</a></li>

--- a/ru/index.html
+++ b/ru/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Руководство по интеграции</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Узнайте важные факты о блокчейне DigiByte с помощью медиа-листа.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Руководство по интеграции</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Медиа-лист DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Логотипы и иконки DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Протокол DGB GitHub</a></li>

--- a/sl/index.html
+++ b/sl/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Navodila za integracijo</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1006,6 +1007,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Hitro preberi pomembne informacije o DigiByte verigi blokov s medijskega letaka.</p>
@@ -1110,6 +1122,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB navodila za integracijo</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB letaki za medije</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logotipi & Ikone</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/sq/index.html
+++ b/sq/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Udhëzues për integrim</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Mësoni faktet e rëndësishme në lidhje me blockchain DigiByte nga fletë media shpejt.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Udhëzues për integrim</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fletë Media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logot dhe ikonat DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protokolli DGB GitHub</a></li>

--- a/sv/index.html
+++ b/sv/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsguide</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1006,6 +1007,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lär dig viktig fakta om DigiBytes blockkedja snabbt med mediearket.</p>
@@ -1111,6 +1123,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrationsguide</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Loggor & Ikoner</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokoll GitHub</a></li>

--- a/sw/index.html
+++ b/sw/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Mwongozo wa ujumuishaji</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Jifunze ukweli muhimu kuhusu blockchain ya DigiByte blockchain kwa kutumia karatasi ya media haraka.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Mwongozo wa Ujumuishaji wa DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Karatasi ya media ya DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Nembo za DGB na Picha</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Itifaki ya DGB kwenye GitHub</a></li>

--- a/th/index.html
+++ b/th/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> คู่มือการเชื่อมต่อ</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>เรียนรู้ข้อเท็จจริงที่สำคัญเกี่ยวกับบล็อคเชน DigiByte โดยแฟ้มข้อมูลเอกสารเพื่อการเผยแพร่อย่างรวดเร็ว</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">คู่มือการรวม DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">กระดานสื่อ DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">โลโก้และไอคอน DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/tr/index.html
+++ b/tr/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Entegrasyon rehberi</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Medya broşüründen DigiByte blockchain hakkında önemli bilgileri hızlı bir şekilde öğrenin.</p>
@@ -1113,6 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Entegresyon Klavuzu</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medya Broşürü</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logolar & Ikonlar</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/vi/index.html
+++ b/vi/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Hướng dẫn tích hợp</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Tìm hiểu các sự thật quan trọng về blockchain DigiByte bằng các phương tiện truyền thông một cách nhanh chóng.</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Hướng dẫn tích hợp DGB</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Tờ thông tin DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo & Biểu tượng DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Giao thức DGB GitHub</a></li>

--- a/zh/index.html
+++ b/zh/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> 添加手册</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1008,6 +1009,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        
+                        <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>通过媒体包了解关于极特币的技术要点。</p>
@@ -1112,6 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">极特币DGB添加教程</a></li>
+                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">极特币DGB媒体包</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">极特币DGB图标</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">极特币DGB协议 GitHub</a></li>


### PR DESCRIPTION
Closes #163

## Summary

Adds a link to the new `docs/DigiDollar_integration_guide.pdf` in three places across every locale `index.html` (root + 35 locale folders, 36 files total), mirroring the existing "Integration guide" pattern.

## What's added per page

1. **Hero CTA pill** &mdash; new "DigiDollar guide" pill next to the existing "Integration guide" pill.
2. **"DigiByte Documents & Guides" slick slider** &mdash; new slide between the Integration guide and Media sheet slides, using `images/digibyte_symbol_06c.svg` as the avatar.
3. **Footer "Resources" list** &mdash; new `<li>` ("DGB DigiDollar Guide") directly under "DGB Integration Guide".

## Asset

- New: `docs/DigiDollar_integration_guide.pdf`
- Reused: `images/digibyte_symbol_06c.svg` (existing DigiByte symbol, no new image asset)

## Notes

- Labels are English across all 36 locales for the initial rollout; translated copy can be a follow-up.
- The `en/index.html` JS-only redirect stub is intentionally not modified.
- Edge cases handled: `ar/` and `fa/` use `<div class="testimonials__slide rtl">` for the slider tile; `bg/index.html` has the hero `home-content__right` block uncommented (all others are commented out).

## Verification

Grep counts across the 36 modified files:

| Check | Count | Expected |
|---|---|---|
| `DigiDollar_integration_guide.pdf` references | 108 | 108 (3 &times; 36) |
| `digibyte_symbol_06c.svg` (slider avatar) | 36 | 36 |
| `DGB DigiDollar Guide` (footer li) | 36 | 36 |
| `DigiDollar guide` (case-insensitive, incl. alt text) | 144 | 144 (4 &times; 36) |

## Out of scope

- Translated label copy per locale.
- Restructuring the home page or a dedicated DigiDollar section.
- Sitemap / news.xml changes (no new pages are introduced).

