### PR TITLE
Add DigiByte Technical Architecture, Security & Ecosystem Guide (07/2026)

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasie gids</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1021,6 +1022,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Leer vinnig die belangrike feite omtrent die DigiByte blokketting op die media bladsy.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrasiegids</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Bladsy</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo's & Ikone</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/ar/index.html
+++ b/ar/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> دليل الدمج</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide rtl">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide rtl">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>تعرف على الحقائق المهمة حول سلسلة DigiByte من خلال ورقة الوسائط بسرعة.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links rtl">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">دليل تكامل DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">ورقة وسائط DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">شعارات وأيقونات DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">بروتوكول DGB GitHub</a></li>

--- a/bg/index.html
+++ b/bg/index.html
@@ -172,6 +172,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Упътване за интеграция</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Научи бързо, важните факти за DigiByte блокчейна, от медийния раздел.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Упътване за интеграция</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Медиен раздел</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Лога & Икони</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB протокол GitHub</a></li>

--- a/cs/index.html
+++ b/cs/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Průvodce integrací</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1021,6 +1022,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Naučte se rychle důležitá fakta o blockchain u DigiByte na médiích.</p>
@@ -1127,6 +1139,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/css/main3p.css
+++ b/css/main3p.css
@@ -3049,6 +3049,7 @@ display: block;
 padding: 0.6em 0 0 0.1em;
 margin-bottom: -1em;
 max-width: 250px;
+white-space: nowrap;
 }
 
 .infopaper:hover {

--- a/da/index.html
+++ b/da/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsvejledning</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lær hurtigt de vigtige fakta om DigiByte blockchain ved hjælp fra mediearket.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrationsvejledning</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logoer & ikoner</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/de/index.html
+++ b/de/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrations-Anleitung</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1016,6 +1017,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lerne die wichtigen Fakten über die DigiByte-Blockchain mithilfe des Medienblatts kennen.</p>
@@ -1122,6 +1134,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrations-Anleitung</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medienblatt</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos und Symbole</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokoll GitHub</a></li>

--- a/el/index.html
+++ b/el/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Οδηγός ενσωμάτωσης</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Γνώρισε τα σημαντικά γεγονότα για το DigiByte.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Οδηγός ενσωμάτωσης</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Φύλλο</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Λογότυπα και Εικονίδια</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB πρωτόκολλο Github</a></li>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration Guide</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1032,6 +1033,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Learn the important facts about the DigiByte blockchain by the media sheet quickly.</p>
@@ -1138,6 +1150,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/es/index.html
+++ b/es/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guía de integración</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1021,6 +1022,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Conozca los hechos importantes sobre la blockchain de DigiByte por la hoja de prensa rápidamente.</p>
@@ -1127,6 +1139,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Guía de integración</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos e Iconos</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/fa/index.html
+++ b/fa/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> راهنمای ادغام</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide rtl">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide rtl">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>حقایق مهم در مورد بلاکچین DigiByte توسط برگه رسانه را به سرعت بیاموزید.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links rtl">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">راهنمای ادغام DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">برگه رسانه DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">آرم و آیکن DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">پروتکل DGB گیتهاب </a></li>

--- a/fi/index.html
+++ b/fi/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrointi ohje</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Opi tärkeät tiedot DigiByte lohkoketjusta nopeasti media kirjasesta.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration ohje</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media kirjanen</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logot & Ikonit</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokolla GitHub</a></li>

--- a/fil/index.html
+++ b/fil/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Alamin ang mahahalagang katotohanan tungkol sa DigiByte blockchain ng media sheet nang mabilis.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/fr/index.html
+++ b/fr/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guide d'intégration</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Apprenez rapidement les faits importants sur la blockchain DigiByte par la fiche média.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guide d'intégration DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fiche média DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logos et icônes DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protocole DGB GitHub</a></li>

--- a/hi/index.html
+++ b/hi/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> एकीकरण गाइड</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1018,6 +1019,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>मीडिया शीट द्वारा DigiByte ब्लॉकचैन के बारे में महत्वपूर्ण तथ्यों को जल्दी से जानें।</p>
@@ -1123,6 +1135,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB एकीकरण गाइड</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB मीडिया शीट</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB लोगो और प्रतीक</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/hr/index.html
+++ b/hr/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i>Vodič za Integraciju</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Naučite bitne činjenice o DigiByte blockchainu iz lista za medije brzo.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Vodič za integraciju</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medijski list</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo i ikone</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/hu/index.html
+++ b/hu/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> ntegrációs útmutató</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Ismerd meg a fontos tényeket a DigiByte blokkláncáról a média oldalon, gyorsan.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrációs Útmutató</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Média Oldal</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logók & Ikonok</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokoll a GitHubon</a></li>

--- a/id/index.html
+++ b/id/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan integrasi</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1012,6 +1013,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Pelajari fakta penting tentang blockchain DigiByte dengan lembar-media dengan cepat.</p>
@@ -1118,6 +1130,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Panduan Integrasi</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Lembar-Media</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo-logo & Ikon-ikon</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
 					<a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1043,6 +1044,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Learn the important facts about the DigiByte blockchain by the media sheet quickly.</p>
@@ -1149,6 +1161,7 @@
                         <ul class="footer__site-links">
                             <li><a href="docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
                             <li><a href="docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/it/index.html
+++ b/it/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guida all'integrazione</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Impara velocemente i punti cardine circa la blockchain di DigiByte.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guida all'integrazione di DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Foglio multimediale DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Loghi e icone DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protocollo DGB GitHub</a></li>

--- a/ja/index.html
+++ b/ja/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> システム構築ガイド</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>広報資料でデジバイトブロックチェーンについての重要な事実を知る。</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGBインテグレーションガイド</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB広報用資料</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGBロゴ＆アイコン</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGBプロトコル GitHub</a></li>

--- a/ms/index.html
+++ b/ms/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan penggabungan</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Ketahui fakta penting mengenai blokrantaian DigiByte melalui lembaran media dengan lebih cepat.</p>
@@ -1124,6 +1136,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Panduan Integrasi DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Helaian Media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo & Ikon DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protokol DGB GitHub</a></li>

--- a/nb/index.html
+++ b/nb/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasjonsveiledning</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lær hurtig de viktige fakta om DigiByte blockchain ved hjelp fra mediearket.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrasjonsguide</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logoer & ikoner</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/nl/index.html
+++ b/nl/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integratiegids</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1018,6 +1019,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Leer snel de belangrijke feiten over de DigiByte-blokketen door het mediablad.</p>
@@ -1124,6 +1136,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integratiehandleiding</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Mediablad</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB-logo's en -pictogrammen</a></li>
 			    			<li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/pl/index.html
+++ b/pl/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Przewodnik integracji</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Szybko poznaj ważne fakty dotyczące DigiByte blockchain w Media Sheet.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Poradnik integracji DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Arkusz mediów DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo i Ikony DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protokół DGB GitHub</a></li>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Aprenda importantes fatos sobre a blockchain DigiByte rapidamente na página da mídia.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guia de Integração DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Página da mídia DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logotipos e ícones DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/pt/index.html
+++ b/pt/index.html
@@ -197,6 +197,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1046,6 +1047,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Aprenda importantes fatos sobre a blockchain DigiByte rapidamente na página da mídia.</p>
@@ -1152,6 +1164,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guia de Integração DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Página da mídia DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logotipos e ícones DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/ro/index.html
+++ b/ro/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Ghid de integrare</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1019,6 +1020,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Aflați rapid informațiile importante despre blockchainul DigiByte prin fișa media.</p>
@@ -1124,6 +1136,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Ghid de integrare DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fișă media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo-uri și pictograme DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protocolul DGB GitHub</a></li>

--- a/ru/index.html
+++ b/ru/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Руководство по интеграции</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Узнайте важные факты о блокчейне DigiByte с помощью медиа-листа.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Руководство по интеграции</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Медиа-лист DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Логотипы и иконки DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Протокол DGB GitHub</a></li>

--- a/sl/index.html
+++ b/sl/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Navodila za integracijo</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1018,6 +1019,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Hitro preberi pomembne informacije o DigiByte verigi blokov s medijskega letaka.</p>
@@ -1123,6 +1135,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB navodila za integracijo</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB letaki za medije</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logotipi & Ikone</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/sq/index.html
+++ b/sq/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Udhëzues për integrim</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Mësoni faktet e rëndësishme në lidhje me blockchain DigiByte nga fletë media shpejt.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Udhëzues për integrim</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fletë Media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logot dhe ikonat DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Protokolli DGB GitHub</a></li>

--- a/sv/index.html
+++ b/sv/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsguide</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1018,6 +1019,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Lär dig viktig fakta om DigiBytes blockkedja snabbt med mediearket.</p>
@@ -1124,6 +1136,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrationsguide</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Loggor & Ikoner</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokoll GitHub</a></li>

--- a/sw/index.html
+++ b/sw/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Mwongozo wa ujumuishaji</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Jifunze ukweli muhimu kuhusu blockchain ya DigiByte blockchain kwa kutumia karatasi ya media haraka.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Mwongozo wa Ujumuishaji wa DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Karatasi ya media ya DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Nembo za DGB na Picha</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Itifaki ya DGB kwenye GitHub</a></li>

--- a/th/index.html
+++ b/th/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> คู่มือการเชื่อมต่อ</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>เรียนรู้ข้อเท็จจริงที่สำคัญเกี่ยวกับบล็อคเชน DigiByte โดยแฟ้มข้อมูลเอกสารเพื่อการเผยแพร่อย่างรวดเร็ว</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">คู่มือการรวม DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">กระดานสื่อ DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">โลโก้และไอคอน DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protocol GitHub</a></li>

--- a/tr/index.html
+++ b/tr/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Entegrasyon rehberi</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Medya broşüründen DigiByte blockchain hakkında önemli bilgileri hızlı bir şekilde öğrenin.</p>
@@ -1126,6 +1138,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Entegresyon Klavuzu</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medya Broşürü</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logolar & Ikonlar</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">DGB Protokol GitHub</a></li>

--- a/vi/index.html
+++ b/vi/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Hướng dẫn tích hợp</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>Tìm hiểu các sự thật quan trọng về blockchain DigiByte bằng các phương tiện truyền thông một cách nhanh chóng.</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Hướng dẫn tích hợp DGB</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Tờ thông tin DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo & Biểu tượng DGB</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">Giao thức DGB GitHub</a></li>

--- a/zh/index.html
+++ b/zh/index.html
@@ -171,6 +171,7 @@
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> 添加手册</a>
 					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
                 <!-- <div class="home-content__right">
@@ -1020,6 +1021,17 @@
                     </div>
 					
 					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte Technical Architecture Guide" class="testimonials__avatar">
+                        
+                        <p>Explore DigiByte's technical architecture, security model and ecosystem in this comprehensive July 2026 guide.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">Technical Architecture guide</span>
+                            <a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
                         <img src="../images/avatars/mediag.png" loading="lazy" width="72" height="72" alt="DigiByte Media Sheet" class="testimonials__avatar">
                         
                         <p>通过媒体包了解关于极特币的技术要点。</p>
@@ -1125,6 +1137,7 @@
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">极特币DGB添加教程</a></li>
                             <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">极特币DGB媒体包</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">极特币DGB图标</a></li>
 			                <li><a href="https://github.com/DigiByte-Core/digibyte" target="_blank">极特币DGB协议 GitHub</a></li>


### PR DESCRIPTION
Adds the new `DigiByte_Technical_Architecture_Security_&_Ecosystem_Guide_07_2026.pdf` under `docs/` and links it from every localized index page.

### Changes
- New PDF: `docs/DigiByte_Technical_Architecture_Security_&_Ecosystem_Guide_07_2026.pdf`
- Linked the guide in three places on the root `index.html` and all 35 language variants:
  1. Hero-section quick-link button (next to Integration guide / DigiDollar guide)
  2. `#docs` (Docs & Guides) carousel — new slide inserted after the DigiDollar slide
  3. Footer resources list (`DGB Technical Architecture Guide`)
- `css/main3p.css`: added `white-space: nowrap` to `.infopaper` so longer button labels (e.g. `Technical Architecture guide`) stay on a single line.

### Notes
- The `&` in the filename is URL-encoded as `%26` in every `href` to keep the link portable across servers.
- Label text is left in English across all locales to match the existing convention used for the DigiDollar guide.
- The `en/` folder is a JS redirect only and has no user-visible content, so it wasn't touched.

<img width="1530" height="595" alt="image" src="https://github.com/user-attachments/assets/f074ccd5-8d36-42d1-97d7-8aa6699083e6" />
