### PR TITLE
Add DigiDollar white paper (08-2026) as an additional resource

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasie gids</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1001,13 +1001,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrasiegids</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Bladsy</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo's & Ikone</a></li>

--- a/af/index.html
+++ b/af/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasie gids</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1001,9 +1002,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/ar/index.html
+++ b/ar/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> دليل الدمج</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide rtl">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links rtl">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">دليل تكامل DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">ورقة وسائط DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">شعارات وأيقونات DGB</a></li>

--- a/ar/index.html
+++ b/ar/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> دليل الدمج</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>

--- a/bg/index.html
+++ b/bg/index.html
@@ -171,6 +171,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Упътване за интеграция</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/bg/index.html
+++ b/bg/index.html
@@ -171,7 +171,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Упътване за интеграция</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Упътване за интеграция</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Медиен раздел</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Лога & Икони</a></li>

--- a/cs/index.html
+++ b/cs/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Průvodce integrací</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1001,9 +1002,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/cs/index.html
+++ b/cs/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Průvodce integrací</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1001,13 +1001,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1128,7 +1128,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>

--- a/css/main3p.css
+++ b/css/main3p.css
@@ -3044,21 +3044,40 @@ cursor: not-allowed!important;
 }
 
 .infopaper {
-color:rgba(255,255,255,0.7);
-display: block;
-padding: 0.6em 0 0 0.1em;
-margin-bottom: -1em;
-max-width: 250px;
+color: rgba(255,255,255,0.75);
+display: inline-flex;
+align-items: center;
+gap: 0.5em;
+padding: 0.45em 0.9em;
+margin: 0.5em 0.5em 0 0;
+background: rgba(255,255,255,0.06);
+border: 1px solid rgba(255,255,255,0.15);
+border-radius: 999px;
+font-size: 0.9em;
+line-height: 1;
 white-space: nowrap;
+transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.infopaper i {
+opacity: 0.85;
 }
 
 .infopaper:hover {
 color: #fff!important;
+background: rgba(255,255,255,0.12);
+border-color: rgba(255,255,255,0.35);
+transform: translateY(-1px);
+}
+
+.rtl .infopaper {
+margin: 0.5em 0 0 0.5em;
 }
 
 @media only screen and (max-width:1200px) {
 .infopaper {
-max-width: 100%;
+font-size: 0.85em;
+padding: 0.4em 0.8em;
 }
 .home-content__btn-wrap .home-content__btn {
 margin-right: 10px;

--- a/da/index.html
+++ b/da/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsvejledning</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/da/index.html
+++ b/da/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsvejledning</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrationsvejledning</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logoer & ikoner</a></li>

--- a/de/index.html
+++ b/de/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrations-Anleitung</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -996,13 +996,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1123,7 +1123,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrations-Anleitung</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medienblatt</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos und Symbole</a></li>

--- a/de/index.html
+++ b/de/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrations-Anleitung</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -996,9 +997,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/el/index.html
+++ b/el/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Οδηγός ενσωμάτωσης</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/el/index.html
+++ b/el/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Οδηγός ενσωμάτωσης</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Οδηγός ενσωμάτωσης</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Φύλλο</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Λογότυπα και Εικονίδια</a></li>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration Guide</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1012,13 +1012,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1139,7 +1139,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration Guide</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1012,9 +1013,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/es/index.html
+++ b/es/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guía de integración</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1001,13 +1001,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1128,7 +1128,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Guía de integración</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos e Iconos</a></li>

--- a/es/index.html
+++ b/es/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guía de integración</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1001,9 +1002,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/fa/index.html
+++ b/fa/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> راهنمای ادغام</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>

--- a/fa/index.html
+++ b/fa/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> راهنمای ادغام</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide rtl">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links rtl">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">راهنمای ادغام DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">برگه رسانه DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">آرم و آیکن DGB</a></li>

--- a/fi/index.html
+++ b/fi/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrointi ohje</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/fi/index.html
+++ b/fi/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrointi ohje</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration ohje</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media kirjanen</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logot & Ikonit</a></li>

--- a/fil/index.html
+++ b/fil/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/fil/index.html
+++ b/fil/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>

--- a/fr/index.html
+++ b/fr/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guide d'intégration</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/fr/index.html
+++ b/fr/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guide d'intégration</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guide d'intégration DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fiche média DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logos et icônes DGB</a></li>

--- a/hi/index.html
+++ b/hi/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> एकीकरण गाइड</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -998,13 +998,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1124,7 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB एकीकरण गाइड</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB मीडिया शीट</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB लोगो और प्रतीक</a></li>

--- a/hi/index.html
+++ b/hi/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> एकीकरण गाइड</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -998,9 +999,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/hr/index.html
+++ b/hr/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i>Vodič za Integraciju</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/hr/index.html
+++ b/hr/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i>Vodič za Integraciju</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Vodič za integraciju</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medijski list</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo i ikone</a></li>

--- a/hu/index.html
+++ b/hu/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> ntegrációs útmutató</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/hu/index.html
+++ b/hu/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> ntegrációs útmutató</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrációs Útmutató</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Média Oldal</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logók & Ikonok</a></li>

--- a/id/index.html
+++ b/id/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan integrasi</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -992,9 +993,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/id/index.html
+++ b/id/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan integrasi</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -992,13 +992,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1119,7 +1119,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Panduan Integrasi</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Lembar-Media</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logo-logo & Ikon-ikon</a></li>

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
-					<a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1023,13 +1023,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1150,7 +1150,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="docs/integrationguide.pdf" target="_blank">DGB Integration Guide</a></li>
-                            <li><a href="docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="docs/mediakit.pdf" target="_blank">DGB Media Sheet</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logos & Icons</a></li>

--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integration guide</a>
+					<a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1023,9 +1024,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/it/index.html
+++ b/it/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guida all'integrazione</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guida all'integrazione di DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Foglio multimediale DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Loghi e icone DGB</a></li>

--- a/it/index.html
+++ b/it/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guida all'integrazione</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/ja/index.html
+++ b/ja/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> システム構築ガイド</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/ja/index.html
+++ b/ja/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> システム構築ガイド</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGBインテグレーションガイド</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB広報用資料</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGBロゴ＆アイコン</a></li>

--- a/ms/index.html
+++ b/ms/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan penggabungan</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1125,7 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Panduan Integrasi DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Helaian Media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo & Ikon DGB</a></li>

--- a/ms/index.html
+++ b/ms/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Panduan penggabungan</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/nb/index.html
+++ b/nb/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasjonsveiledning</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrasjonsguide</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logoer & ikoner</a></li>

--- a/nb/index.html
+++ b/nb/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrasjonsveiledning</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/nl/index.html
+++ b/nl/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integratiegids</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -998,9 +999,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/nl/index.html
+++ b/nl/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integratiegids</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -998,13 +998,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1125,7 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integratiehandleiding</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Mediablad</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB-logo's en -pictogrammen</a></li>

--- a/pl/index.html
+++ b/pl/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Przewodnik integracji</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/pl/index.html
+++ b/pl/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Przewodnik integracji</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Poradnik integracji DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Arkusz mediów DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo i Ikony DGB</a></li>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guia de Integração DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Página da mídia DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logotipos e ícones DGB</a></li>

--- a/pt/index.html
+++ b/pt/index.html
@@ -196,6 +196,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1026,9 +1027,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/pt/index.html
+++ b/pt/index.html
@@ -196,7 +196,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Guia de integração</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1026,13 +1026,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1153,7 +1153,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Guia de Integração DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Página da mídia DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logotipos e ícones DGB</a></li>

--- a/ro/index.html
+++ b/ro/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Ghid de integrare</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -999,9 +1000,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/ro/index.html
+++ b/ro/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Ghid de integrare</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -999,13 +999,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1125,7 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Ghid de integrare DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fișă media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo-uri și pictograme DGB</a></li>

--- a/ru/index.html
+++ b/ru/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Руководство по интеграции</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Руководство по интеграции</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Медиа-лист DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Логотипы и иконки DGB</a></li>

--- a/ru/index.html
+++ b/ru/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Руководство по интеграции</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/sl/index.html
+++ b/sl/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Navodila za integracijo</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -998,13 +998,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1124,7 +1124,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB navodila za integracijo</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB letaki za medije</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logotipi & Ikone</a></li>

--- a/sl/index.html
+++ b/sl/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Navodila za integracijo</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -998,9 +999,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/sq/index.html
+++ b/sq/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Udhëzues për integrim</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Udhëzues për integrim</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Fletë Media DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logot dhe ikonat DGB</a></li>

--- a/sq/index.html
+++ b/sq/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Udhëzues për integrim</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/sv/index.html
+++ b/sv/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsguide</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -998,9 +999,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/sv/index.html
+++ b/sv/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Integrationsguide</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -998,13 +998,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1125,7 +1125,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Integrationsguide</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medieark</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Loggor & Ikoner</a></li>

--- a/sw/index.html
+++ b/sw/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Mwongozo wa ujumuishaji</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/sw/index.html
+++ b/sw/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Mwongozo wa ujumuishaji</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Mwongozo wa Ujumuishaji wa DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Karatasi ya media ya DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Nembo za DGB na Picha</a></li>

--- a/th/index.html
+++ b/th/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> คู่มือการเชื่อมต่อ</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">คู่มือการรวม DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">กระดานสื่อ DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">โลโก้และไอคอน DGB</a></li>

--- a/th/index.html
+++ b/th/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> คู่มือการเชื่อมต่อ</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/tr/index.html
+++ b/tr/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Entegrasyon rehberi</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/tr/index.html
+++ b/tr/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Entegrasyon rehberi</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1127,7 +1127,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">DGB Entegresyon Klavuzu</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">DGB Medya Broşürü</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">DGB Logolar & Ikonlar</a></li>

--- a/vi/index.html
+++ b/vi/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Hướng dẫn tích hợp</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">Hướng dẫn tích hợp DGB</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">Tờ thông tin DGB</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">Logo & Biểu tượng DGB</a></li>

--- a/vi/index.html
+++ b/vi/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Hướng dẫn tích hợp</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>

--- a/zh/index.html
+++ b/zh/index.html
@@ -170,7 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> 添加手册</a>
-					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
+					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
 
@@ -1000,13 +1000,13 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
 
                         <div class="testimonials__author">
-                            <span class="testimonials__name">DigiDollar guide</span>
-                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                            <span class="testimonials__name">DigiDollar white paper</span>
+                            <a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="testimonials__link">Download</a>
                         </div>
                     </div>
 					
@@ -1126,7 +1126,7 @@
 
                         <ul class="footer__site-links">
                             <li><a href="../docs/integrationguide.pdf" target="_blank">极特币DGB添加教程</a></li>
-                            <li><a href="../docs/DigiDollar_integration_guide.pdf" target="_blank">DGB DigiDollar Guide</a></li>
+                            <li><a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank">DGB DigiDollar white paper</a></li>
                             <li><a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank">DGB Technical Architecture Guide</a></li>
                             <li><a href="../docs/mediakit.pdf" target="_blank">极特币DGB媒体包</a></li>
                             <li><a href="https://github.com/DigiByte-Core/digibyte-logos" target="_blank">极特币DGB图标</a></li>

--- a/zh/index.html
+++ b/zh/index.html
@@ -170,6 +170,7 @@
                     </div>
 					
 					<a href="../docs/integrationguide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> 添加手册</a>
+					<a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar guide</a>
 					<a href="../docs/DigiDollar_white-paper_08-2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> DigiDollar white paper</a>
 					<a href="../docs/DigiByte_Technical_Architecture_Security_%26_Ecosystem_Guide_07_2026.pdf" target="_blank" class="infopaper"><i class="fab fa-readme"></i> Technical Architecture guide</a>
                 </div>
@@ -1000,9 +1001,20 @@
                     </div>
 					
 					<div class="testimonials__slide">
-                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar Guide" class="testimonials__avatar">
                         
                         <p>Implement DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in your wallet, exchange or service.</p>
+
+                        <div class="testimonials__author">
+                            <span class="testimonials__name">DigiDollar guide</span>
+                            <a href="../docs/DigiDollar_integration_guide.pdf" target="_blank" class="testimonials__link">Download</a>
+                        </div>
+                    </div>
+					
+					<div class="testimonials__slide">
+                        <img src="../images/digibyte_symbol_06c.svg" loading="lazy" width="72" height="72" alt="DigiByte DigiDollar White Paper" class="testimonials__avatar">
+                        
+                        <p>Read the technical foundation of DigiDollar &mdash; DigiByte's native USD-pegged stablecoin &mdash; in this August 2026 white paper.</p>
 
                         <div class="testimonials__author">
                             <span class="testimonials__name">DigiDollar white paper</span>


### PR DESCRIPTION
Adds the new `DigiDollar_white-paper_08-2026.pdf` as an additional resource across the main site and all 35 language variants. The existing DigiDollar integration guide entry is preserved.

**Per file:**
- Header nav: new `DigiDollar white paper` link added next to the existing `DigiDollar guide` link
- Testimonials/CTA slider: new white paper slide added next to the existing DigiDollar guide slide

**Files touched:** 36 `index.html` files + new `docs/DigiDollar_white-paper_08-2026.pdf`