### PR TITLE
fix(ci): remove stray digibyte submodule gitlink breaking actions/checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ deploy.php
 # Add php files used elsewhere
 rates.php
 ajax.php
+
+# Local Core source checkout (not part of the website)
+digibyte/


### PR DESCRIPTION
### Problem

`actions/checkout@v4` fails on this repo with:

```
fatal: No url found for submodule path 'digibyte' in .gitmodules
Error: The process '/usr/bin/git' failed with exit code 128
```

Example failing run: https://github.com/DigiByte-Core/DigiByte.org/actions/runs/30958026357

### Root cause

The repo's tree contains a submodule gitlink at path `digibyte` (mode `160000`, pinned to `8a3fd47b943ff883e51bf988dc9bac92916274dc`) but **no matching `.gitmodules`** file at the root. So whenever `actions/checkout` runs `git submodule update --init --recursive` it can't resolve a URL for the `digibyte` path and aborts.

Verified with:

```
$ git ls-tree HEAD digibyte
160000 commit 8a3fd47b943ff883e51bf988dc9bac92916274dc	digibyte
$ git ls-tree HEAD .gitmodules   # empty
```

The gitlink was introduced accidentally (likely because a nested `.git` was present inside a local `digibyte/` working copy at `git add` time). The DigiByte Core source isn't part of the Jekyll website, so the gitlink is just dangling data.

### Fix

- Remove the stray `digibyte` gitlink from the tree (`git rm --cached digibyte`).
- Add `digibyte/` to `.gitignore` so a local Core source checkout can't be re-added accidentally.

Diff is only 2 files: `.gitignore` (+3) and removal of the `digibyte` gitlink entry.

### Impact

- Unblocks CI / Pages workflows that use `submodules: true` or `submodules: recursive`.
- No user-visible / site-content change.
- Local `digibyte/` working directories on contributors' machines are untouched (only the index entry is removed).

### Note on the "Node 20 deprecation" banner

The `Node 20 is being deprecated` line in the failing log is unrelated runner-level info and did not cause the failure.
