### PR TITLE
Fix DigiAssets 'Protocol docs' button link (#176)

### DIFF
--- a/af/index.html
+++ b/af/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokol-dokumentasie</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokol-dokumentasie</a>
 		</div>
 	</div>
 </section>

--- a/ar/index.html
+++ b/ar/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">توثيق البروتوكول</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">توثيق البروتوكول</a>
 		</div>
 	</div>
 </section>

--- a/bg/index.html
+++ b/bg/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Документация на протокола</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Документация на протокола</a>
 		</div>
 	</div>
 </section>

--- a/cs/index.html
+++ b/cs/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentace protokolu</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentace protokolu</a>
 		</div>
 	</div>
 </section>

--- a/da/index.html
+++ b/da/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokol-dokumentation</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokol-dokumentation</a>
 		</div>
 	</div>
 </section>

--- a/de/index.html
+++ b/de/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-Dokumentation</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-Dokumentation</a>
 		</div>
 	</div>
 </section>

--- a/el/index.html
+++ b/el/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Τεκμηρίωση πρωτοκόλλου</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Τεκμηρίωση πρωτοκόλλου</a>
 		</div>
 	</div>
 </section>

--- a/en-us/index.html
+++ b/en-us/index.html
@@ -443,7 +443,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol docs</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol docs</a>
 		</div>
 	</div>
 </section>

--- a/en/index.html
+++ b/en/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol docs</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol docs</a>
 		</div>
 	</div>
 </section>

--- a/es/index.html
+++ b/es/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentación del protocolo</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentación del protocolo</a>
 		</div>
 	</div>
 </section>

--- a/fa/index.html
+++ b/fa/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">مستندات پروتکل</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">مستندات پروتکل</a>
 		</div>
 	</div>
 </section>

--- a/fi/index.html
+++ b/fi/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokolladokumentaatio</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokolladokumentaatio</a>
 		</div>
 	</div>
 </section>

--- a/fil/index.html
+++ b/fil/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentasyon ng protocol</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentasyon ng protocol</a>
 		</div>
 	</div>
 </section>

--- a/fr/index.html
+++ b/fr/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Docs du protocole</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Docs du protocole</a>
 		</div>
 	</div>
 </section>

--- a/hi/index.html
+++ b/hi/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">प्रोटोकॉल दस्तावेज़</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">प्रोटोकॉल दस्तावेज़</a>
 		</div>
 	</div>
 </section>

--- a/hr/index.html
+++ b/hr/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacija protokola</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacija protokola</a>
 		</div>
 	</div>
 </section>

--- a/hu/index.html
+++ b/hu/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-dokumentáció</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-dokumentáció</a>
 		</div>
 	</div>
 </section>

--- a/id/index.html
+++ b/id/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentasi protokol</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentasi protokol</a>
 		</div>
 	</div>
 </section>

--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol docs</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol docs</a>
 		</div>
 	</div>
 </section>

--- a/it/index.html
+++ b/it/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentazione protocollo</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentazione protocollo</a>
 		</div>
 	</div>
 </section>

--- a/ja/index.html
+++ b/ja/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">プロトコルドキュメント</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">プロトコルドキュメント</a>
 		</div>
 	</div>
 </section>

--- a/ms/index.html
+++ b/ms/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentasi protokol</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentasi protokol</a>
 		</div>
 	</div>
 </section>

--- a/nb/index.html
+++ b/nb/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-dokumentasjon</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-dokumentasjon</a>
 		</div>
 	</div>
 </section>

--- a/nl/index.html
+++ b/nl/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol-documentatie</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protocol-documentatie</a>
 		</div>
 	</div>
 </section>

--- a/pl/index.html
+++ b/pl/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacja protokołu</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacja protokołu</a>
 		</div>
 	</div>
 </section>

--- a/pt-br/index.html
+++ b/pt-br/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Docs do protocolo</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Docs do protocolo</a>
 		</div>
 	</div>
 </section>

--- a/pt/index.html
+++ b/pt/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentação do protocolo</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentação do protocolo</a>
 		</div>
 	</div>
 </section>

--- a/ro/index.html
+++ b/ro/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentația protocolului</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Documentația protocolului</a>
 		</div>
 	</div>
 </section>

--- a/ru/index.html
+++ b/ru/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Документация протокола</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Документация протокола</a>
 		</div>
 	</div>
 </section>

--- a/sl/index.html
+++ b/sl/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacija protokola</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacija protokola</a>
 		</div>
 	</div>
 </section>

--- a/sq/index.html
+++ b/sq/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacion i protokollit</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Dokumentacion i protokollit</a>
 		</div>
 	</div>
 </section>

--- a/sv/index.html
+++ b/sv/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-dokumentation</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokoll-dokumentation</a>
 		</div>
 	</div>
 </section>

--- a/sw/index.html
+++ b/sw/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Nyaraka za protokoli</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Nyaraka za protokoli</a>
 		</div>
 	</div>
 </section>

--- a/th/index.html
+++ b/th/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">เอกสารโปรโตคอล</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">เอกสารโปรโตคอล</a>
 		</div>
 	</div>
 </section>

--- a/tr/index.html
+++ b/tr/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokol dokümantasyonu</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Protokol dokümantasyonu</a>
 		</div>
 	</div>
 </section>

--- a/vi/index.html
+++ b/vi/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Tài liệu giao thức</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">Tài liệu giao thức</a>
 		</div>
 	</div>
 </section>

--- a/zh/index.html
+++ b/zh/index.html
@@ -441,7 +441,7 @@
 		</div>
 
 		<div class="cluster mt-7 justify-center-children" data-reveal>
-			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/digibyte/wiki" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">协议文档</a>
+			<a class="btn btn--primary" href="https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications" target="_blank" rel="noopener" data-i18n="digiassets.cta.docs">协议文档</a>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
## Summary

The `Protocol docs` CTA button in the DigiAssets section on the homepage currently links to the generic DigiByte wiki (https://github.com/DigiByte-Core/digibyte/wiki), which does not contain DigiAssets protocol documentation.

This PR points the button to the DigiAssets Protocol Specifications repository, which is the best available reference for the DigiAssets protocol (as noted in the issue).

- Before: `https://github.com/DigiByte-Core/digibyte/wiki`
- After:  `https://github.com/DigiByte-Core/DigiAssets-Protocol-Specifications`

## Scope

Applied to the `Protocol docs` button (identified by `data-i18n="digiassets.cta.docs"`) in the root `index.html` plus all 36 localized `<lang>/index.html` files. No other wiki links (e.g. the tokenomics `Read the wiki` CTA) were touched.

Fixes #176